### PR TITLE
icon customization doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Customize Icons
 To customize the icons used in a native bundle, you have to provide the icons for the appropriate bundle.
 The icons must follow the file name convention in order to get picked up.
 
-> Tip: Set the `verbose` setting to true, to have log which files are picked up from your deploy directory.
+> Tip: Set the `verbose` setting to true, to log which files are picked up from your deploy directory.
 
 ## macOS
 Icon location: `src/main/delploy/macosx`

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The icons must follow the file name convention in order to get picked up.
 > Tip: Set the `verbose` setting to true, to log which files are picked up from your deploy directory.
 
 ## macOS
-Icon location: `src/main/delploy/macosx`
+Icon location: `src/main/deploy/package/macosx`
 
 In macOS you can provide up to three different icons.
 * .app icon
@@ -228,7 +228,7 @@ The icon sizes should follow the specified sizes.
 http://iconhandbook.co.uk/reference/chart/osx/
 
 ## Linux
-Icon location: `src/main/deploy/linux`
+Icon location: `src/main/deploy/package/linux`
 
 For Linux you can provide one icon.
 
@@ -242,7 +242,7 @@ The icon file name is depended on your `appName` setting of this plugin.
 For example a name like 'foo Bar' will lookup for a icon like 'fooBar.png'
 
 ## Windows
-Icon location: `src/main/deploy/windows`
+Icon location: `src/main/deploy/package/windows`
 
 For Windows you can provide two different icons.
 * application icon

--- a/README.md
+++ b/README.md
@@ -200,6 +200,60 @@ jfx {
 }
 ```
 
+Customize Icons
+===============
+
+To customize the icons used in a native bundle, you have to provide the icons for the appropriate bundle.
+The icons must follow the file name convention in order to get picked up.
+
+> Tip: Set the `verbose` setting to true, to have log which files are picked up from your deploy directory.
+
+## macOS
+Icon location: `src/main/delploy/macosx`
+
+In macOS you can provide up to three different icons.
+* .app icon
+* volume icon
+* the background of the window, when opening the dmg volume
+
+The icon file name is depended on your `appName` setting of this plugin.
+
+| Type              | Filename                  |
+| :---------------- |:------------------------- |
+| .app icon         | \<appName>.icns           |
+| volume icon       | \<appName>-volume.icns    |
+| volume background | \<appName>-background.png |
+
+The icon sizes should follow the specified sizes.
+http://iconhandbook.co.uk/reference/chart/osx/
+
+## Linux
+Icon location: `src/main/deploy/linux`
+
+For Linux you can provide one icon.
+
+The icon file name is depended on your `appName` setting of this plugin.
+
+| Type              | Filename        |
+| :---------------- |:--------------- |
+| application icon  | \<appName>.png  |
+
+>Whitespaces in the `appName` will be removed in order to lookup for the icon.
+For example a name like 'foo Bar' will lookup for a icon like 'fooBar.png'
+
+## Windows
+Icon location: `src/main/deploy/windows`
+
+For Windows you can provide two different icons.
+* application icon
+* setup icon - the icon of the installer
+
+| Type              | Filename                  |
+| :---------------- |:------------------------- |
+| .exe icon         | \<appName>.ico            |
+| setup exe icon    | \<appName>-setup-icon.bmp |
+
+
 Gradle Tasks
 ============
 


### PR DESCRIPTION
I added a section for how to customize the icons used in a native bundle to the readme file.

Its just about icons in the deploy directory, additional files which can be used there, such as pre-install scripts etc. are not included in the section.