### PR TITLE
feat: add ability to use array of commands as runJavaParameters

### DIFF
--- a/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePluginExtension.java
+++ b/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePluginExtension.java
@@ -100,6 +100,8 @@ public class JavaFXGradlePluginExtension {
     private String runJavaParameter = null;
     private String runAppParameter = null;
 
+    private List<String> runJavaParameters = null;
+
     // generic settings (not present on javafx-maven-plugin)
     private String alternativePathToJarFile = null;
     private boolean usePatchedJFXAntLib = true;
@@ -629,4 +631,11 @@ public class JavaFXGradlePluginExtension {
         this.checkForAbsolutePaths = checkForAbsolutePaths;
     }
 
+    public List<String> getRunJavaParameters() {
+        return runJavaParameters;
+    }
+
+    public void setRunJavaParameters(List<String> runJavaParameters) {
+        this.runJavaParameters = runJavaParameters;
+    }
 }

--- a/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/tasks/workers/JfxRunWorker.java
+++ b/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/tasks/workers/JfxRunWorker.java
@@ -41,12 +41,21 @@ public class JfxRunWorker extends JfxAbstractWorker {
 
         List<String> command = new ArrayList<>();
         command.add(getEnvironmentRelativeExecutablePath(ext.isUseEnvironmentRelativeExecutables()) + "java");
+
         Optional.ofNullable(ext.getRunJavaParameter()).ifPresent(runJavaParameter -> {
             if( runJavaParameter.trim().isEmpty() ){
                 return;
             }
             command.add(runJavaParameter);
         });
+
+        Optional.ofNullable(ext.getRunJavaParameters()).ifPresent(runJavaParameters -> {
+            if( runJavaParameters.isEmpty() ){
+                return;
+            }
+            command.addAll(runJavaParameters);
+        });
+
         command.add("-jar");
         command.add(ext.getJfxMainAppJarName());
         Optional.ofNullable(ext.getRunAppParameter()).ifPresent(runAppParameter -> {


### PR DESCRIPTION
Hi @FibreFoX. It seems that `command.add(runJavaParameter);` not properly works with multiple parameters (related to issue  #77). 

This PR adds new variable `runJavaParameters` to avoid breaking changes. `runJavaParameters` works with array of params.

Example:

```
jfx {
    verbose = true
    mainClass = 'com.test.javafx.App'
    vendor = 'YourName'
    appName = 'SimpleAppName'
    runJavaParameters = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
}
```