### PR TITLE
Skip packager.jar in Java 9 and later

### DIFF
--- a/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePluginExtension.java
+++ b/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePluginExtension.java
@@ -15,6 +15,8 @@
  */
 package de.dynamicfiles.projects.gradle.plugins.javafx;
 
+import de.dynamicfiles.projects.gradle.plugins.javafx.tasks.internal.JavaDetectionTools;
+
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +42,8 @@ public class JavaFXGradlePluginExtension {
     private boolean updateExistingJar = false;
     private boolean allPermissions = false;
     private Map<String, String> manifestAttributes = null;
-    private boolean addPackagerJar = true;
+    // NB! There is no 'packager.jar' in Java 9 and later. Only copy the jar if using Java 8.
+    private boolean addPackagerJar = JavaDetectionTools.IS_JAVA_8;
     // private List<Dependency> classpathExcludes = new ArrayList<>();
     // private boolean classpathExcludesTransient = true;
     private boolean copyAdditionalAppResourcesToJar = false;


### PR DESCRIPTION
There is no packager.jar in Java 9 or later, which will make the task `jfxJar` fail. This patch resolves this error by changing the `addPackagerJar`parameter's default from `true` to depend on Java version 8.