### PR TITLE
fixed issue with java 10 not being able to find javafx ant jar

### DIFF
--- a/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePlugin.java
+++ b/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/JavaFXGradlePlugin.java
@@ -100,7 +100,7 @@ public class JavaFXGradlePlugin implements Plugin<Project> {
         String jfxAntJarPath = "/../lib/" + ANT_JAVAFX_JAR_FILENAME;
 
         // on java 9, we have a different path
-        if( JavaDetectionTools.IS_JAVA_9 ){
+        if( JavaDetectionTools.IS_JAVA_9 || JavaDetectionTools.IS_JAVA_10 ){
             jfxAntJarPath = "/lib/" + ANT_JAVAFX_JAR_FILENAME;
         }
 

--- a/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/tasks/internal/JavaDetectionTools.java
+++ b/src/main/java/de/dynamicfiles/projects/gradle/plugins/javafx/tasks/internal/JavaDetectionTools.java
@@ -21,7 +21,8 @@ package de.dynamicfiles.projects.gradle.plugins.javafx.tasks.internal;
 public class JavaDetectionTools {
 
     public static final boolean IS_JAVA_8 = isJavaVersion(8);
-    public static final boolean IS_JAVA_9 = !IS_JAVA_8 && isJavaVersion(9) || isJavaVersion(9, true);
+    public static final boolean IS_JAVA_9 = !IS_JAVA_8 && (isJavaVersion(9) || isJavaVersion(9, true));
+    public static final boolean IS_JAVA_10 = !IS_JAVA_8 && !IS_JAVA_9 && (isJavaVersion(10) || isJavaVersion(10, true));
 
     public static boolean isJavaVersion(int oracleJavaVersion, boolean noVersionOne) {
         String javaVersion = System.getProperty("java.version");


### PR DESCRIPTION
There was an issue where if you had JAVA 10 JDK installed on Windows the ../lib relative path wasn't to be found in JAVA_HOME and your app throws a GradleException error. This is fixing that because in Java 10 the lib/ dir is NOT outside the JDK folder.. it sits inside it. This PR should fix the issue. 